### PR TITLE
Allow other plugins to modify/cancel messages from Discord

### DIFF
--- a/src/main/java/com/rezzedup/discordsrv/staffchat/StaffChatPlugin.java
+++ b/src/main/java/com/rezzedup/discordsrv/staffchat/StaffChatPlugin.java
@@ -133,19 +133,16 @@ public class StaffChatPlugin extends JavaPlugin
         else { debugger.debug("Unable to send message to discord: %s => null", CHANNEL); }
     }
     
-    public void submitFromDiscord(User user, Message message)
+    public void submitFromDiscord(User user, Message message, String processedMessage)
     {
         debugger.debug(
-            "[Discord-Message] From:\"%s#%s\" Channel:\"%s\" Message:\"%s\"",
-            user.getName(), user.getDiscriminator(), message.getChannel(), message
+            "[Discord-Message] From:\"%s#%s\" Channel:\"%s\" Message:\"%s\" Processed Message:\"%s\"",
+            user.getName(), user.getDiscriminator(), message.getChannel(), message, processedMessage
         );
     
-        // Emoji Unicode -> Alias (library included with DiscordSRV)
-        String text = EmojiParser.parseToAliases(message.getContentStripped());
-        
         MappedPlaceholder placholders = new MappedPlaceholder();
         
-        placholders.map("message", "content", "text").to(() -> text);
+        placholders.map("message", "content", "text").to(() -> processedMessage);
         placholders.map("user", "name", "username", "sender").to(user::getName);
         placholders.map("nickname", "displayname").to(message.getGuild().getMember(user)::getNickname);
         placholders.map("discriminator", "discrim").to(user::getDiscriminator);

--- a/src/main/java/com/rezzedup/discordsrv/staffchat/listeners/DiscordStaffChatListener.java
+++ b/src/main/java/com/rezzedup/discordsrv/staffchat/listeners/DiscordStaffChatListener.java
@@ -1,8 +1,9 @@
 package com.rezzedup.discordsrv.staffchat.listeners;
 
 import com.rezzedup.discordsrv.staffchat.StaffChatPlugin;
+import github.scarsz.discordsrv.api.ListenerPriority;
 import github.scarsz.discordsrv.api.Subscribe;
-import github.scarsz.discordsrv.api.events.DiscordGuildMessagePreProcessEvent;
+import github.scarsz.discordsrv.api.events.DiscordGuildMessagePostProcessEvent;
 
 public class DiscordStaffChatListener
 {
@@ -10,12 +11,12 @@ public class DiscordStaffChatListener
     
     public DiscordStaffChatListener(StaffChatPlugin plugin) { this.plugin = plugin; }
     
-    @Subscribe
-    public void onDiscordChat(DiscordGuildMessagePreProcessEvent event)
+    @Subscribe(priority = ListenerPriority.HIGHEST)
+    public void onDiscordChat(DiscordGuildMessagePostProcessEvent event)
     {
         if (event.getChannel().equals(plugin.getDiscordChannel()))
         {
-            plugin.submitFromDiscord(event.getAuthor(), event.getMessage());
+            plugin.submitFromDiscord(event.getAuthor(), event.getMessage(), event.getProcessedMessage());
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
Switched listener to listen on PostProcessEvent instead of PreProcessEvent, which will allow other plugins to modify or cancel messages sent from Discord.